### PR TITLE
Add ha.hass-discovery and fix mqtt.sub-topic in snap get -d example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ $ snap get -d theengs-gateway
                 "discovery": 1,
                 "discovery-device-name": "TheengsGateway",
                 "discovery-filter": "IBEACON GAEN MS-CDP",
-                "discovery-topic": "homeassistant/sensor"
+                "discovery-topic": "homeassistant/sensor",
+                "hass-discovery": 1
         },
         "log-level": "WARNING",
         "mqtt": {
@@ -51,7 +52,7 @@ $ snap get -d theengs-gateway
                 "pass": "",
                 "port": 1883,
                 "pub-topic": "home/TheengsGateway/BTtoMQTT",
-                "sub-topic": "home/TheengsGateway/+",
+                "sub-topic": "home/+/BTtoMQTT/undecoded",
                 "user": ""
         }
 }


### PR DESCRIPTION
## Description:

Fixes the `snap get -d` output in the README to be consistent with Theengs Gateway 0.6.0.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
