### PR TITLE
Add architecture badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 [![Check status](https://github.com/theengs/gateway-appliance/workflows/Checks/badge.svg)](https://github.com/theengs/gateway-appliance/actions)
 [![GitHub license](https://img.shields.io/github/license/theengs/gateway-appliance.svg)](https://github.com/theengs/gateway-appliance/blob/development/LICENSE)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/theengs/gateway-appliance?label=Theengs%20Gateway)](https://github.com/theengs/gateway-appliance/releases)
+![amd64](https://img.shields.io/badge/amd64-yes-green.svg)
+![arm64](https://img.shields.io/badge/pi_arm64-yes-green.svg)
+![armhf](https://img.shields.io/badge/pi_armhf-yes-green.svg)
 
 # Theengs Gateway Appliance
 [Ubuntu Core](https://ubuntu.com/core) appliance with [Theengs Gateway](https://github.com/theengs/gateway) pre-installed 


### PR DESCRIPTION
## Description:

Add badges for the supported architectures to README file.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
